### PR TITLE
Fixing third parameter on fwrite file when a exception is throw

### DIFF
--- a/src/PEARX/Channel.php
+++ b/src/PEARX/Channel.php
@@ -110,7 +110,7 @@ class Channel
                 }
             } catch( Exception $e ) {
                 fwrite( STDERR , "PEAR Channel discover failed: $host\n" );
-                fwrite( STDERR , $e->getMessage(), "\n" );
+                fwrite( STDERR , $e->getMessage() . "\n" );
             }
         }
 


### PR DESCRIPTION
When PEARX fail to discover channel it should write to php://stderr but it cannot write exception message because the third parameter is wrong. This branch fix that.
