### PR TITLE
Redeclared corneltek/cachekit as a development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,17 @@
     "name": "corneltek/pearx",
     "homepage": "http://github.com/phpbrew/PEARX",
     "description": "PEAR channel client",
+    "config": {
+        "platform": {
+            "php": "5.3.9"
+        }
+    },
     "require": {
         "php": ">=5.3.0",
-        "corneltek/cachekit": "^1",
         "corneltek/curlkit": "^1.0.11"
     },
     "require-dev": {
+        "corneltek/cachekit": "^1",
         "corneltek/phpunit-testmore": "dev-master",
         "phpunit/phpunit": "^4.8||^5.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,49 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33dfeae619dd8126aa13a5ed4c88a712",
+    "content-hash": "2d0dd3d8df733978ce522a16458c5fce",
     "packages": [
+        {
+            "name": "corneltek/curlkit",
+            "version": "1.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/c9s/CurlKit.git",
+                "reference": "5f0765bd6e81d66ec6f71d24c6312a1509e65c5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/c9s/CurlKit/zipball/5f0765bd6e81d66ec6f71d24c6312a1509e65c5f",
+                "reference": "5f0765bd6e81d66ec6f71d24c6312a1509e65c5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "corneltek/phpunit-testmore": "dev-master",
+                "phpunit/phpunit": "^4.0||^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CurlKit\\": "src/CurlKit/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Curl Kit",
+            "time": "2019-12-03T23:37:27+00:00"
+        }
+    ],
+    "packages-dev": [
         {
             "name": "corneltek/cachekit",
             "version": "1.0.0",
@@ -49,43 +90,30 @@
             "time": "2013-12-29T15:53:59+00:00"
         },
         {
-            "name": "corneltek/curlkit",
-            "version": "1.0.11",
+            "name": "corneltek/phpunit-testmore",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/c9s/CurlKit.git",
-                "reference": "5f0765bd6e81d66ec6f71d24c6312a1509e65c5f"
+                "url": "https://github.com/c9s/PHPUnit_TestMore.git",
+                "reference": "1b3728bfbc23c7ac89836fbec9a0b2aab6be8c9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/CurlKit/zipball/5f0765bd6e81d66ec6f71d24c6312a1509e65c5f",
-                "reference": "5f0765bd6e81d66ec6f71d24c6312a1509e65c5f",
+                "url": "https://api.github.com/repos/c9s/PHPUnit_TestMore/zipball/1b3728bfbc23c7ac89836fbec9a0b2aab6be8c9f",
+                "reference": "1b3728bfbc23c7ac89836fbec9a0b2aab6be8c9f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
-            "require-dev": {
-                "corneltek/phpunit-testmore": "dev-master",
-                "phpunit/phpunit": "^4.0||^5.0"
-            },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "CurlKit\\": "src/CurlKit/"
-                }
+                "files": [
+                    "TestMore.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Curl Kit",
-            "time": "2019-12-03T23:37:27+00:00"
+            "time": "2017-03-09T16:13:38+00:00"
         },
         {
             "name": "corneltek/serializerkit",
@@ -116,142 +144,6 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "time": "2013-12-01T14:32:14+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.13-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2019-11-27T13:56:44+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v2.8.52",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/02c1859112aa779d9ab394ae4f3381911d84052b",
-                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-11-11T11:18:13+00:00"
-        }
-    ],
-    "packages-dev": [
-        {
-            "name": "corneltek/phpunit-testmore",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/c9s/PHPUnit_TestMore.git",
-                "reference": "1b3728bfbc23c7ac89836fbec9a0b2aab6be8c9f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/c9s/PHPUnit_TestMore/zipball/1b3728bfbc23c7ac89836fbec9a0b2aab6be8c9f",
-                "reference": "1b3728bfbc23c7ac89836fbec9a0b2aab6be8c9f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "TestMore.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "time": "2017-03-09T16:13:38+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1167,6 +1059,114 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.52",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/02c1859112aa779d9ab394ae4f3381911d84052b",
+                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-11-11T11:18:13+00:00"
         }
     ],
     "aliases": [],
@@ -1179,5 +1179,8 @@
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.3.9"
+    }
 }


### PR DESCRIPTION
Although `corneltek/cachekit` is used in tests, PEARX itself doesn't depend on it. The unnecessary dependency not only increases the size of of the package but also imposes unnecessary version constraints on the common libraries like `symfony/*` which may be used by the application and prevent further dependency upgrades.