### PR TITLE
Add PHP 7.2 config setting and PHP 7.2~8.2 tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,11 @@
     "name": "corneltek/pearx",
     "homepage": "http://github.com/phpbrew/PEARX",
     "description": "PEAR channel client",
+    "config": {
+        "platform": {
+            "php": "7.2.5"
+        }
+    },
     "require": {
         "php": ">=7.2.5",
         "corneltek/curlkit": "^1.0.11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bc563e3bd7020214f809dd17e25681c",
+    "content-hash": "164a5c1e3555d50b25baa2bd5e3d8c5b",
     "packages": [
         {
             "name": "corneltek/curlkit",
@@ -43,6 +43,10 @@
                 "MIT"
             ],
             "description": "Curl Kit",
+            "support": {
+                "issues": "https://github.com/c9s/CurlKit/issues",
+                "source": "https://github.com/c9s/CurlKit/tree/master"
+            },
             "time": "2019-12-03T23:37:27+00:00"
         }
     ],
@@ -87,6 +91,10 @@
             ],
             "description": "General cache interface",
             "homepage": "http://github.com/c9s/CacheKit",
+            "support": {
+                "issues": "https://github.com/c9s/CacheKit/issues",
+                "source": "https://github.com/c9s/CacheKit/tree/1.0.0"
+            },
             "time": "2013-12-29T15:53:59+00:00"
         },
         {
@@ -95,16 +103,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/c9s/PHPUnit_TestMore.git",
-                "reference": "fd8a1aabd471d8850d1bec7a5d133ee05f848e49"
+                "reference": "3f40f450f0f26f073a7183787a0a7232b97a5b59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/c9s/PHPUnit_TestMore/zipball/fd8a1aabd471d8850d1bec7a5d133ee05f848e49",
-                "reference": "fd8a1aabd471d8850d1bec7a5d133ee05f848e49",
+                "url": "https://api.github.com/repos/c9s/PHPUnit_TestMore/zipball/3f40f450f0f26f073a7183787a0a7232b97a5b59",
+                "reference": "3f40f450f0f26f073a7183787a0a7232b97a5b59",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2.3"
+                "php": ">=7.2.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5"
             },
             "default-branch": true,
             "type": "library",
@@ -118,7 +129,7 @@
                 "issues": "https://github.com/c9s/PHPUnit_TestMore/issues",
                 "source": "https://github.com/c9s/PHPUnit_TestMore/tree/master"
             },
-            "time": "2023-02-24T15:35:57+00:00"
+            "time": "2023-04-19T16:53:12+00:00"
         },
         {
             "name": "corneltek/serializerkit",
@@ -148,6 +159,10 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
+            "support": {
+                "issues": "https://github.com/c9s/php-SerializerKit/issues",
+                "source": "https://github.com/c9s/php-SerializerKit/tree/1.1.0"
+            },
             "time": "2013-12-01T14:32:14+00:00"
         },
         {
@@ -1643,6 +1658,9 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v2.8.52"
+            },
             "time": "2018-11-11T11:18:13+00:00"
         },
         {
@@ -1707,5 +1725,8 @@
         "php": ">=7.2.5"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2.5"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
# Changed log

- Since the [PR ](https://github.com/c9s/PHPUnit_TestMore/pull/3)is merged, it can add the `PHP 7.2` config back.
- Adding from `PHP 7.2` to `8.2` tests during GitHub action running.